### PR TITLE
added a new spike option to disable the default bootrom at resetpc

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -42,7 +42,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
              const std::vector<std::string>& args,
              const debug_module_config_t &dm_config,
              const char *log_path,
-             bool dtb_enabled, const char *dtb_file,
+             bool dtb_enabled, bool rom_enabled, const char *dtb_file,
              bool socket_enabled,
              FILE *cmd_file) // needed for command line option --cmd
   : htif_t(args),
@@ -51,6 +51,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
     mems(mems),
     procs(std::max(cfg->nprocs(), size_t(1))),
     dtb_enabled(dtb_enabled),
+    rom_enabled(rom_enabled),
     log_file(log_path),
     cmd_file(cmd_file),
     sout_(nullptr),
@@ -401,7 +402,7 @@ const char* sim_t::get_symbol(uint64_t paddr)
 
 void sim_t::reset()
 {
-  if (dtb_enabled)
+  if (rom_enabled)
     set_rom();
 }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -402,7 +402,7 @@ const char* sim_t::get_symbol(uint64_t paddr)
 
 void sim_t::reset()
 {
-  if (rom_enabled)
+  if (dtb_enabled && rom_enabled)
     set_rom();
 }
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -30,7 +30,7 @@ public:
         std::vector<device_factory_t*> plugin_device_factories,
         const std::vector<std::string>& args,
         const debug_module_config_t &dm_config, const char *log_path,
-        bool dtb_enabled, const char *dtb_file,
+        bool dtb_enabled, bool rom_enabled, const char *dtb_file,
         bool socket_enabled,
         FILE *cmd_file); // needed for command line option --cmd
   ~sim_t();
@@ -75,6 +75,7 @@ private:
   std::string dts;
   std::string dtb;
   bool dtb_enabled;
+  bool rom_enabled;
   std::vector<std::shared_ptr<abstract_device_t>> devices;
   std::shared_ptr<clint_t> clint;
   std::shared_ptr<plic_t> plic;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -67,6 +67,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --dump-dts            Print device tree string and exit\n");
   fprintf(stderr, "  --dtb=<path>          Use specified device tree blob [default: auto-generate]\n");
   fprintf(stderr, "  --disable-dtb         Don't write the device tree blob into memory\n");
+  fprintf(stderr, "  --disable-rom         Dont enable the default bootrom at reset PC\n");
   fprintf(stderr, "  --kernel=<path>       Load kernel flat image into memory\n");
   fprintf(stderr, "  --initrd=<path>       Load kernel initrd into memory\n");
   fprintf(stderr, "  --bootargs=<args>     Provide custom bootargs for kernel [default: %s]\n",
@@ -375,6 +376,7 @@ int main(int argc, char** argv)
   bool UNUSED socket = false;  // command line option -s
   bool dump_dts = false;
   bool dtb_enabled = true;
+  bool rom_enabled = true;
   const char* kernel = NULL;
   reg_t kernel_offset, kernel_size;
   std::vector<device_factory_t*> plugin_device_factories;
@@ -460,6 +462,7 @@ int main(int argc, char** argv)
   parser.option(0, "extension", 1, [&](const char* s){extensions.push_back(find_extension(s));});
   parser.option(0, "dump-dts", 0, [&](const char UNUSED *s){dump_dts = true;});
   parser.option(0, "disable-dtb", 0, [&](const char UNUSED *s){dtb_enabled = false;});
+  parser.option(0, "disable-rom", 0, [&](const char UNUSED *s){rom_enabled = false;});
   parser.option(0, "dtb", 1, [&](const char *s){dtb_file = s;});
   parser.option(0, "kernel", 1, [&](const char* s){kernel = s;});
   parser.option(0, "initrd", 1, [&](const char* s){initrd = s;});
@@ -573,7 +576,7 @@ int main(int argc, char** argv)
   }
 
   sim_t s(&cfg, halted,
-      mems, plugin_device_factories, htif_args, dm_config, log_path, dtb_enabled, dtb_file,
+      mems, plugin_device_factories, htif_args, dm_config, log_path, dtb_enabled, rom_enabled, dtb_file,
       socket,
       cmd_file);
   std::unique_ptr<remote_bitbang_t> remote_bitbang((remote_bitbang_t *) NULL);


### PR DESCRIPTION
This will enable a new spike option called --disable-rom, which will just disable the default bootrom at resetpc. This gives users an option just to replace the default bootrom without disabling the dtb.